### PR TITLE
fix(ci): correct release workflow and resolve lint error

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -93,12 +93,6 @@ jobs:
         with:
           inputs: >-
             ./dist/*.tar.gz ./dist/*.whl
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY"
-          --notes ""
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1,3 +1,5 @@
+"""Server entry point."""
+
 import sys
 
 from server import main


### PR DESCRIPTION
- Removes duplicate 'gh release create' step in python-publish.yml
- Adds missing module docstring to server/__main__.py
