### PR TITLE
fix(ci): improve release upload robustness and update readme badge

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -99,6 +99,7 @@ jobs:
         # Upload to GitHub Release using the `gh` CLI.
         # `dist/` contains the built packages, and the
         # sigstore-produced signatures and certificates.
+        # --clobber overwrites existing assets
         run: >-
           gh release upload "$GITHUB_REF_NAME" dist/** --repo
-          "$GITHUB_REPOSITORY"
+          "$GITHUB_REPOSITORY" --clobber

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
 
 [![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/cobrowser.svg?style=social&label=Follow%20%40cobrowser)](https://x.com/cobrowser)
-[![PyPI version](https://badge.fury.io/py/browser-use-mcp-server.svg)](https://pypi.org/project/browser-use-mcp-server/)
+[![PyPI version](https://badge.fury.io/py/browser-use-mcp-server.svg)](https://badge.fury.io/py/browser-use-mcp-server)
 
 **An MCP server that enables AI agents to control web browsers using
 [browser-use](https://github.com/browser-use/browser-use).**


### PR DESCRIPTION
- Add --clobber flag to gh release upload for idempotent asset uploads.
- Correct PyPI badge URL in README.md.